### PR TITLE
Collect coverage for files that have no coverage so we get more accurate numbers.

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,9 @@
     "lint": "eslint '*/**/*.{js,jsx,ts,tsx}'"
   },
   "jest": {
+    "collectCoverageFrom": [
+      "src/!(assets)/**/!(sx).js"
+    ],
     "transform": {
       "^.+\\.jsx?$": "<rootDir>/jest/preprocess.js"
     },


### PR DESCRIPTION
With this change our test coverage will include all .js files in `src`, excluding the `assets` folder and any `sx.js` files.

Previously we were only collecting coverage based on the test.js files found, so the coverage numbers are misleadingly high.