### PR TITLE
MARBLE-1637 Use OIDC token for GraphQL auth instead of API key.

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -4,7 +4,7 @@
 
 # local keys
 S3_DEST_BUCKET="ci-bucket"
-GRAPHQL_API_KEY_KEY_PATH="/graphqlpath"
+GRAPHQL_API_KEY_BASE_PATH="/all/stacks/<MYSTACKNAME>/" # set to the ssm path of maintain-metadata stack outputs
 AUTH_CLIENT_URL='https://okta.nd.edu'
 AUTH_CLIENT_ID='0oa4tlda8nvJGLv9i357'
 AUTH_CLIENT_ISSUER='https://okta.nd.edu/oauth2/ausxosq06SDdaFNMB356'

--- a/.env.production
+++ b/.env.production
@@ -1,7 +1,6 @@
 # keys from infastructure env
 # S3_DEST_BUCKET
 # GRAPHQL_KEY_BASE
-# GRAPHQL_API_KEY
 # GRAPHQL_API_URL
 
 # local keys

--- a/.env.production-test
+++ b/.env.production-test
@@ -2,7 +2,6 @@
 # keys from infastructure env
 # S3_DEST_BUCKET
 # GRAPHQL_KEY_BASE
-# GRAPHQL_API_KEY
 # GRAPHQL_API_URL
 
 # local keys

--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,3 @@
-GRAPHQL_API_KEY='apikey'
 GRAPHQL_API_URL='apiurl'
 AUTH_CLIENT_URL='https://okta.nd.edu'
 AUTH_CLIENT_ID=''

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,7 +8,6 @@ require('dotenv').config({
 })
 
 const s3BucketName = process.env.S3_DEST_BUCKET || ''
-const graphqlApiKey = process.env.GRAPHQL_API_KEY || ''
 const graphqlApiUrl = process.env.GRAPHQL_API_URL || ''
 const authClientURL = process.env.AUTH_CLIENT_URL || ''
 const authClientClientId = process.env.AUTH_CLIENT_ID || ''
@@ -16,7 +15,6 @@ const authClientIssuer = process.env.AUTH_CLIENT_ISSUER || ''
 const marbleUrl = process.env.MARBLE_URL || ''
 
 console.table([
-  { variable: 'GRAPHQL_API_KEY:', value: graphqlApiKey },
   { variable: 'GRAPHQL_API_URL:', value: graphqlApiUrl },
   { variable: 'AUTH_CLIENT_URL:', value: authClientURL },
   { variable: 'AUTH_CLIENT_ID:', value: authClientClientId },
@@ -32,7 +30,6 @@ module.exports = {
     author: 'WSE',
     marbleUrl: marbleUrl,
     apis: {
-      graphqlApiKey: graphqlApiKey,
       graphqlApiUrl: graphqlApiUrl,
     },
     auth: {

--- a/scripts/codebuild/setupEnv.js
+++ b/scripts/codebuild/setupEnv.js
@@ -4,7 +4,6 @@ const AWS = require('aws-sdk')
 const appConfig = process.argv.slice(2)[0]
 
 const possibleKeys = [
-  'GRAPHQL_API_KEY',
   'GRAPHQL_API_URL',
   'AUTH_CLIENT_ID',
   'AUTH_CLIENT_URL',

--- a/scripts/setup-development.sh
+++ b/scripts/setup-development.sh
@@ -1,6 +1,5 @@
 cp .env.development-example .env.development
 
-GRAPHQL_API_KEY_BASE_PATH='/all/stacks/sm-test-maintain-metadata/'
 # add the app sync keys to the env
 node ./scripts/codebuild/setupEnv.js ${GRAPHQL_API_KEY_BASE_PATH} >> '.env.development' --unhandled-rejections=strict
 

--- a/src/components/Layout/AuthWrapper/index.js
+++ b/src/components/Layout/AuthWrapper/index.js
@@ -18,9 +18,10 @@ const AuthWrapper = ({ children }) => {
     }
   `)
 
-  const setAuth = (user) => {
+  const setAuth = (token, user) => {
     setContext({
       ...context,
+      token: token,
       user: user,
     })
   }

--- a/src/components/Layout/PrivateRoute/index.js
+++ b/src/components/Layout/PrivateRoute/index.js
@@ -22,7 +22,7 @@ const PrivateRoute = ({ component: Component, location, ...props }) => {
       authClient.tokenManager.get('idToken')
         .then(idToken => {
           if (idToken) {
-            setAuth(idToken.claims)
+            setAuth(idToken.value, idToken.claims)
             setShouldRender(true)
           } else {
             // You're not logged in, you need a sessionToken

--- a/src/components/Pages/AllCollections/index.js
+++ b/src/components/Pages/AllCollections/index.js
@@ -4,6 +4,7 @@ import Loading from 'components/Layout/Loading'
 import ErrorMessage from 'components/Layout/ErrorMessage'
 import Content from './Content'
 import { useAPIContext } from 'context/APIContext'
+import { useAuthContext } from 'context/AuthContext'
 
 export const fetchStatus = {
   NOT_FETCHED: 'NOT_FETCHED',
@@ -20,8 +21,13 @@ const AllCollections = ({ location }) => {
   const [importCollectionStatus, setImportCollectionStatus] = useState(fetchStatus.NOT_FETCHED)
   const [errorMsg, setErrorMsg] = useState()
 
-  const { graphqlApiKey, graphqlApiUrl } = useAPIContext()
+  const { token } = useAuthContext()
+  const { graphqlApiUrl } = useAPIContext()
   useEffect(() => {
+    if (!token) {
+      return
+    }
+
     const abortController = new AbortController()
     const query = `query {
         listItemsBySourceSystem(id: "ARCHIVESSPACE", limit: 1000) {
@@ -36,7 +42,7 @@ const AllCollections = ({ location }) => {
       graphqlApiUrl,
       {
         headers: {
-          'x-api-key': graphqlApiKey,
+          Authorization: token,
           'Content-Type': 'application/json',
         },
         method: 'POST',
@@ -58,9 +64,13 @@ const AllCollections = ({ location }) => {
     return () => {
       abortController.abort()
     }
-  }, [location, graphqlApiUrl, graphqlApiKey])
+  }, [location, graphqlApiUrl, token])
 
   useEffect(() => {
+    if (!token) {
+      return
+    }
+
     const abortController = new AbortController()
     const query = `query {
         listItemsBySourceSystem(id: "ALEPH", limit: 1000) {
@@ -75,7 +85,7 @@ const AllCollections = ({ location }) => {
       graphqlApiUrl,
       {
         headers: {
-          'x-api-key': graphqlApiKey,
+          Authorization: token,
           'Content-Type': 'application/json',
         },
         method: 'POST',
@@ -97,7 +107,7 @@ const AllCollections = ({ location }) => {
     return () => {
       abortController.abort()
     }
-  }, [location, graphqlApiUrl, graphqlApiKey])
+  }, [location, graphqlApiUrl, token])
 
   const importCollectionFunction = ({ itemUrl, sourceSystem }) => {
     const abortController = new AbortController()
@@ -116,7 +126,7 @@ const AllCollections = ({ location }) => {
       graphqlApiUrl,
       {
         headers: {
-          'x-api-key': graphqlApiKey,
+          Authorization: token,
           'Content-Type': 'application/json',
         },
         method: 'POST',

--- a/src/components/Pages/Collection/Content/ItemDetails/Item/index.js
+++ b/src/components/Pages/Collection/Content/ItemDetails/Item/index.js
@@ -7,6 +7,7 @@ import {
 
 import Loading from 'components/Layout/Loading'
 import { useAPIContext } from 'context/APIContext'
+import { useAuthContext } from 'context/AuthContext'
 import Content from './Content'
 
 export const fetchStatus = {
@@ -18,13 +19,18 @@ export const fetchStatus = {
 const Item = ({ item, depth }) => {
   const [itemStatus, setItemStatus] = useState(fetchStatus.FETCHING)
   const [itemNeedsReloaded, setItemNeedsReloaded] = useState(1)
-  const { graphqlApiKey, graphqlApiUrl } = useAPIContext()
+  const { graphqlApiUrl } = useAPIContext()
+  const { token } = useAuthContext()
   const [editableData, setEditableData] = useState(false)
 
   const id = item.id
   useEffect(() => {
+    if (!token) {
+      return
+    }
+
     const abortController = new AbortController()
-    fetchAndParseCollection(id, graphqlApiUrl, graphqlApiKey, abortController)
+    fetchAndParseCollection(id, graphqlApiUrl, token, abortController)
       .then((result) => {
         setEditableData(result)
         setItemStatus(fetchStatus.SUCCESS)
@@ -34,18 +40,17 @@ const Item = ({ item, depth }) => {
         // setErrorMsg(error)
         // setCollectionStatus(fetchStatus.ERROR)
       })
-  }, [graphqlApiKey, graphqlApiUrl, id, itemNeedsReloaded])
+  }, [token, graphqlApiUrl, id, itemNeedsReloaded])
 
   const updateItemFunction = ({ itemId, generalDefaultFilePath, generalObjectFileGroupId, generalPartiallyDigitized }) => {
     const abortController = new AbortController()
-    console.log(itemId, generalDefaultFilePath, generalObjectFileGroupId, generalPartiallyDigitized, graphqlApiKey, graphqlApiUrl, abortController)
 
     updateItemFunctionBase({
       itemId: itemId,
       generalDefaultFilePath: generalDefaultFilePath,
       generalObjectFileGroupId: generalObjectFileGroupId,
       generalPartiallyDigitized: generalPartiallyDigitized,
-      graphqlApiKey: graphqlApiKey,
+      token: token,
       graphqlApiUrl: graphqlApiUrl,
       abortController: abortController,
     })

--- a/src/components/Pages/Login/index.js
+++ b/src/components/Pages/Login/index.js
@@ -30,7 +30,7 @@ const Login = ({ location }) => {
         authClient.tokenManager.get('idToken')
           .then(idToken => {
             if (idToken) {
-              setAuth(idToken.claims)
+              setAuth(idToken.value, idToken.claims)
               navigate(redirectPath)
               // If ID Token isn't found, try to parse it from the current URL
             } else if (location.hash) {
@@ -38,7 +38,7 @@ const Login = ({ location }) => {
                 .then(res => {
                   const { idToken } = res.tokens
                   authClient.tokenManager.add('idToken', idToken)
-                  setAuth(idToken.claims)
+                  setAuth(idToken.value, idToken.claims)
                   navigate(redirectPath)
                 })
             } else {

--- a/src/context/AuthContext/index.js
+++ b/src/context/AuthContext/index.js
@@ -1,6 +1,7 @@
 import { createContext, useContext } from 'react'
 export const initialContext = {
   authSettings: {},
+  token: null,
   user: null,
   setAuth: () => {},
 }

--- a/src/context/CollectionContext/index.js
+++ b/src/context/CollectionContext/index.js
@@ -41,13 +41,13 @@ const collectionGrapgqlQuery = (id) => {
   `
 }
 
-export const fetchAndParseCollection = (id, graphqlApiUrl, graphqlApiKey, abortController) => {
+export const fetchAndParseCollection = (id, graphqlApiUrl, token, abortController) => {
   const query = collectionGrapgqlQuery(id)
   return fetch(
     graphqlApiUrl,
     {
       headers: {
-        'x-api-key': graphqlApiKey,
+        Authorization: token,
         'Content-Type': 'application/json',
       },
       method: 'POST',
@@ -64,8 +64,7 @@ export const fetchAndParseCollection = (id, graphqlApiUrl, graphqlApiKey, abortC
     })
 }
 
-export const updateItemFunctionBase = ({ itemId, generalDefaultFilePath, generalObjectFileGroupId, generalPartiallyDigitized, graphqlApiKey, graphqlApiUrl, abortController }) => {
-  console.log(itemId, generalDefaultFilePath, generalObjectFileGroupId, generalPartiallyDigitized, graphqlApiKey, graphqlApiUrl, abortController)
+export const updateItemFunctionBase = ({ itemId, generalDefaultFilePath, generalObjectFileGroupId, generalPartiallyDigitized, token, graphqlApiUrl, abortController }) => {
   let query = ''
   if (typeof generalPartiallyDigitized !== 'undefined') {
     query = `mutation {
@@ -95,7 +94,7 @@ export const updateItemFunctionBase = ({ itemId, generalDefaultFilePath, general
     graphqlApiUrl,
     {
       headers: {
-        'x-api-key': graphqlApiKey,
+        Authorization: token,
         'Content-Type': 'application/json',
       },
       method: 'POST',

--- a/src/pages/collection.js
+++ b/src/pages/collection.js
@@ -17,7 +17,6 @@ const CollectionPages = ({ location }) => {
       site {
         siteMetadata {
           apis {
-            graphqlApiKey
             graphqlApiUrl
           }
         }
@@ -28,13 +27,11 @@ const CollectionPages = ({ location }) => {
   const setAPIs = (apis) => {
     setApiContext({
       ...apiContext,
-      graphqlApiKey: apis.graphqlApiKey,
       graphqlApiUrl: apis.graphqlApiUrl,
     })
   }
   const [apiContext, setApiContext] = useState({
     ...initialApiContext,
-    graphqlApiKey: apis.graphqlApiKey,
     graphqlApiUrl: apis.graphqlApiUrl,
     setAPIs: setAPIs,
   })


### PR DESCRIPTION
I opted not to use gatsby-plugin-okta for a few reasons:

- It's sort of marked experimental/WIP.
- It hasn't had any commits since shortly after it was published. Unclear if it will be maintained.
- It doesn't appear to do much significantly different from what we are already doing. It might be fewer lines of code overall, but it was easier to stick with what was in place.
- It looked like I would have had to hardcode the redirect uri, unless I set up another environment variable with the hostname. The existing implementation gets the React location so it's a bit cleaner and more flexible.