### PR TITLE
MARBLE-1682 Fix aleph items not loading due to invalid properties.

### DIFF
--- a/src/components/Pages/Collection/index.js
+++ b/src/components/Pages/Collection/index.js
@@ -63,11 +63,7 @@ const Collection = ({ id, location }) => {
             items {
               objectFileGroupId
               id
-              title
-              source
-              sourceType
               filePath
-              iiifImageUri
               mediaServer
               mediaResourceId
             }


### PR DESCRIPTION
There was a validation error on iiifImageUri. It didn't look like any of these properties were being used by the frontend so I simply removed them from the query.