### PR TITLE
MARBLE-2125 Fix record truncation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: Node Unit Test CI
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
@@ -14,24 +14,24 @@ jobs:
         node-version: [14.x]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - uses: c-hive/gha-yarn-cache@v1
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - uses: c-hive/gha-yarn-cache@v1
 
-    - name: "Install Main App"
-      run: |
-        yarn global add gatsby-cli
-        mkdir ~/.config/gatsby
-        cp ./scripts/codebuild/config.json ~/.config/gatsby/
-        yarn install
-        cp ".env.test" ".env.production"
+      - name: 'Install Main App'
+        run: |
+          yarn global add gatsby-cli@4.24.0
+          mkdir ~/.config/gatsby
+          cp ./scripts/codebuild/config.json ~/.config/gatsby/
+          yarn install
+          cp ".env.test" ".env.production"
 
-    - name: "Unit Tests"
-      run: yarn test
+      - name: 'Unit Tests'
+        run: yarn test
 
-    - name: "Build"
-      run: |
-        yarn build
+      - name: 'Build'
+        run: |
+          yarn build

--- a/src/components/Pages/Collection/Content/ItemDetails/Item/Content/index.js
+++ b/src/components/Pages/Collection/Content/ItemDetails/Item/Content/index.js
@@ -14,7 +14,7 @@ import typy from 'typy'
 import Item from '../'
 
 const Content = ({ item, depth, updateItemFunction, updateCopyrightFunction }) => {
-  const [expanded, setExpanded] = useState(true)
+  const [expanded, setExpanded] = useState(false)
 
   let thumbnail = ''
   const defaultImage = determineDefaultImage(item)

--- a/src/context/CollectionContext/index.js
+++ b/src/context/CollectionContext/index.js
@@ -42,7 +42,7 @@ const collectionGrapgqlQuery = (id) => {
           mediaResourceId
         }
       }
-      children {
+      children(limit: 10000) {
         items {
           id
         }


### PR DESCRIPTION
This is a workaround patch that fixes the issue at hand (not displaying all the child records). Long term this is not sustainable as it can send a ridiculous number of api requests.

**Problem**: The size of the Pfefer collection is making it cut off at some point in the Photographs listing, so only 14 boxes are displayed (this is similar to a front end issue we resolved in the summer). it jumps from PFE700-14-46 to PFE701-1-1, and about 21 boxes of material aren't listed.

**Solution:** Increase the hard limit of the number of children returned from AppSync to the maximum allowable. Additionally, we are collapsing the child tree by default. This by itself does not reduce the number of calls, but it does reduce the number of things rendered to the DOM.