### PR TITLE
Fix non-secret secrets and Okta 400 error

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -9,9 +9,9 @@ require('dotenv').config({
 
 const s3BucketName = process.env.S3_DEST_BUCKET || 'ci-bucket'
 const graphqlApiUrl = process.env.GRAPHQL_API_URL || ''
-const authClientURL = process.env.AUTH_CLIENT_URL || 'https://okta.nd.edu'
-const authClientClientId = process.env.AUTH_CLIENT_ID || '0oa4tlda8nvJGLv9i357'
-const authClientIssuer = process.env.AUTH_CLIENT_ISSUER || 'https://okta.nd.edu/oauth2/ausxosq06SDdaFNMB356'
+const authClientURL = 'https://okta.nd.edu'
+const authClientClientId = '0oa4tlda8nvJGLv9i357'
+const authClientIssuer = 'https://okta.nd.edu/oauth2/ausxosq06SDdaFNMB356'
 const marbleUrl = process.env.BUILD_ENVIRONMENT === 'production' ? 'https://marble.nd.edu' : 'https://marble-test.library.nd.edu'
 
 console.table([


### PR DESCRIPTION
This was pointed to the wrong credentials. Since the right credentials are already hard coded as fall backs and they are not actual secrets, but merely variables let's just take out the Secret Manager env variable.